### PR TITLE
Add Join Substack navigation menu item and adjust positioning

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -44,6 +44,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>

--- a/css/custom.css
+++ b/css/custom.css
@@ -142,7 +142,7 @@ img[src*="container5.png"] {
 /* Desktop positioning for navigation menu */
 @media (min-width: 992px) {
   .navigation-menu {
-    left: 600px;
+    left: 450px;
   }
 }
 

--- a/faq.html
+++ b/faq.html
@@ -49,6 +49,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" aria-current="page" class="navigation-link w-nav-link w--current">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>

--- a/instructors.html
+++ b/instructors.html
@@ -49,6 +49,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" aria-current="page" class="navigation-link w-nav-link w--current">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -44,6 +44,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>

--- a/sba101.html
+++ b/sba101.html
@@ -44,6 +44,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -44,6 +44,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>

--- a/thankyou.html
+++ b/thankyou.html
@@ -44,6 +44,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
+              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>


### PR DESCRIPTION
- Add "Join Substack" menu item to all pages navigation
- Links to https://supersmallai.substack.com/ in new tab
- Position between FAQ and Apply Now in menu order
- Adjust navigation menu positioning to left: 450px for optimal visibility
- Ensure menu items are not hidden behind Apply Now button

🤖 Generated with [Claude Code](https://claude.ai/code)