### PR TITLE
Add cohort selection question to application form

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -236,6 +236,31 @@
                   <label for="commitment" class="form-field-label-styled">On a scale of 1-10, how serious are you about launching a business in the next 90 days?</label>
                   <input class="form-text-field-styled w-input" maxlength="2" name="commitment" placeholder="1-10" type="number" min="1" max="10" id="commitment">
                 </div>
+
+                <div class="column-x-small-4">
+                  <label class="form-field-label-styled">Which cohort are you most interested in joining? <span class="required-star">*</span></label>
+                  <p class="form-field-hint">(Choose one)</p>
+                  <div style="margin-top: 15px;">
+                    <label style="display: block; margin-bottom: 20px; cursor: pointer; padding: 15px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9;">
+                      <input type="radio" name="cohort" value="November Cohort (Nov 3 – Nov 21, 3 weeks) - Regular Price: $1,495, With discounts: $495" required style="margin-right: 8px;">
+                      <div style="font-weight: bold; margin-bottom: 5px;">November Cohort (Nov 3 – Nov 21, 3 weeks)</div>
+                      <div style="margin-bottom: 3px;">Regular Price: $1,495</div>
+                      <div style="color: #007f00; font-weight: bold;">With $500 SBA Discount + $500 Social Discount → $495</div>
+                    </label>
+                    <label style="display: block; margin-bottom: 20px; cursor: pointer; padding: 15px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9;">
+                      <input type="radio" name="cohort" value="January Cohort (Jan 5 – Feb 13, 6 weeks) - Regular Price: $2,495, With discounts: $1,495" required style="margin-right: 8px;">
+                      <div style="font-weight: bold; margin-bottom: 5px;">January Cohort (Jan 5 – Feb 13, 6 weeks)</div>
+                      <div style="margin-bottom: 3px;">Regular Price: $2,495</div>
+                      <div style="color: #007f00; font-weight: bold;">With $500 SBA Discount + $500 Social Discount → $1,495</div>
+                    </label>
+                    <label style="display: block; margin-bottom: 20px; cursor: pointer; padding: 15px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9;">
+                      <input type="radio" name="cohort" value="March Cohort (Mar 2 – Apr 10, 6 weeks) - Regular Price: $2,495, With discounts: $1,495" required style="margin-right: 8px;">
+                      <div style="font-weight: bold; margin-bottom: 5px;">March Cohort (Mar 2 – Apr 10, 6 weeks)</div>
+                      <div style="margin-bottom: 3px;">Regular Price: $2,495</div>
+                      <div style="color: #007f00; font-weight: bold;">With $500 SBA Discount + $500 Social Discount → $1,495</div>
+                    </label>
+                  </div>
+                </div>
               </div>
 
               <div class="application-form-section">


### PR DESCRIPTION
Added new required field for cohort selection with three options:
- November Cohort (3 weeks) - $1,495 → $495 with discounts
- January Cohort (6 weeks) - $2,495 → $1,495 with discounts
- March Cohort (6 weeks) - $2,495 → $1,495 with discounts

Features radio button selection with clear pricing display showing regular price and discounted price with SBA and Social discounts.

🤖 Generated with [Claude Code](https://claude.ai/code)