### PR TITLE
Update pricing display and add SuperSmall Community comparison row

### DIFF
--- a/apply-supervip.html
+++ b/apply-supervip.html
@@ -78,8 +78,7 @@
             <div class="column-large-3">
               <div class="contact-row">
                 <p class="paragraph-small-16">Our most comprehensive program: 6-week SuperCohort plus extended 1-on-1 support, priority access, and 3 months of post-program guidance.</p>
-                <br>
-                <p class="paragraph-small-16" style="text-align: left;">Investment: $14,495</p>
+                <p class="paragraph-small-16"><strong>Investment: $9995</strong></p>
               </div>
             </div>
           </div>

--- a/apply.html
+++ b/apply.html
@@ -482,7 +482,7 @@
         <div class="program-card">
           <h3 class="program-title bangers-regular2">SuperVIP</h3>
           <p class="program-subtitle">Extended VIP Support</p>
-          <div class="program-price">$14,495</div>
+          <div class="program-price">$9,995</div>
           <p class="program-price-note">Maximum support & guidance</p>
           <ul class="checklist">
             <li>Everything in SuperCohort</li>
@@ -538,6 +538,14 @@
           <div class="plan-cell">4-hour live workshop</div>
           <div class="plan-cell">3–6 week guided cohort</div>
           <div class="plan-cell">1:1 advisory + lifetime access</div>
+        </div>
+        
+        <div class="comparison-row">
+          <div class="feature-cell">Access to SuperSmall Community</div>
+          <div class="plan-cell">Month-to-Month</div>
+          <div class="plan-cell">Free 3 months</div>
+          <div class="plan-cell">Free 6 months</div>
+          <div class="plan-cell">Free for life</div>
         </div>
         
         <div class="comparison-row">
@@ -630,10 +638,10 @@
         
         <div class="comparison-row price-row">
           <div class="feature-cell price-cell">Price</div>
-          <div class="plan-cell price-cell">$99 / mo</div>
+          <div class="plan-cell price-cell">$99/month</div>
           <div class="plan-cell price-cell">$299</div>
-          <div class="plan-cell price-cell">$1495</div>
-          <div class="plan-cell price-cell">$9995</div>
+          <div class="plan-cell price-cell">$1,495</div>
+          <div class="plan-cell price-cell">$9,995</div>
         </div>
         
         


### PR DESCRIPTION
- Add new comparison row "Access to SuperSmall Community" showing benefits for each program level
- Update SuperVIP pricing from $14,495 to $9,995 across all locations
- Improve pricing formatting with proper comma separators ($1,495, $9,995)
- Change SuperCommunity pricing display from "$99 / mo" to "$99/month"
- Update SuperVIP page description and remove extra spacing for better alignment
- Standardize pricing terminology to "Investment: $9995" on SuperVIP page

🤖 Generated with [Claude Code](https://claude.ai/code)