### PR TITLE
Update Substack URL from supersmallai.substack.com to supersmall.subs…

### DIFF
--- a/apply-supercohort.html
+++ b/apply-supercohort.html
@@ -59,7 +59,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <!-- <a href="faq.html" class="navigation-link w-nav-link">FAQ</a> -->
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -292,7 +292,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -301,7 +301,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/apply-supercommunity.html
+++ b/apply-supercommunity.html
@@ -61,7 +61,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <!-- <a href="faq.html" class="navigation-link w-nav-link">FAQ</a> -->
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -245,7 +245,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -254,7 +254,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/apply-supervip.html
+++ b/apply-supervip.html
@@ -53,7 +53,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <!-- <a href="faq.html" class="navigation-link w-nav-link">FAQ</a> -->
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -256,7 +256,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -265,7 +265,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/apply-superworkshop.html
+++ b/apply-superworkshop.html
@@ -53,7 +53,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <!-- <a href="faq.html" class="navigation-link w-nav-link">FAQ</a> -->
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Choose Program</a>
             </nav>
           </div>
@@ -255,7 +255,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -264,7 +264,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/apply.html
+++ b/apply.html
@@ -392,7 +392,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <!-- <a href="faq.html" class="navigation-link w-nav-link">FAQ</a> -->
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -659,7 +659,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -668,7 +668,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/faq.html
+++ b/faq.html
@@ -58,7 +58,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" aria-current="page" class="navigation-link w-nav-link w--current">FAQ</a>
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -364,7 +364,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -373,7 +373,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <!-- <a href="faq.html" class="navigation-link w-nav-link">FAQ</a> -->
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -353,7 +353,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -362,7 +362,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/instructors.html
+++ b/instructors.html
@@ -58,7 +58,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" aria-current="page" class="navigation-link w-nav-link w--current">About</a>
               <!-- <a href="faq.html" class="navigation-link w-nav-link">FAQ</a> -->
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join our Substack Community</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -149,7 +149,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -158,7 +158,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -53,7 +53,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -118,7 +118,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -127,7 +127,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/sba101.html
+++ b/sba101.html
@@ -53,7 +53,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -301,7 +301,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -310,7 +310,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -53,7 +53,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -121,7 +121,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -130,7 +130,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>

--- a/thankyou.html
+++ b/thankyou.html
@@ -53,7 +53,7 @@
             <nav role="navigation" class="navigation-menu w-nav-menu">
               <a href="instructors.html" class="navigation-link w-nav-link">About</a>
               <a href="faq.html" class="navigation-link w-nav-link">FAQ</a>
-              <a href="https://supersmallai.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
+              <a href="https://supersmall.substack.com/" target="_blank" class="navigation-link w-nav-link">Join Substack</a>
               <a href="apply.html" class="navigation-link w-nav-link mobile-only-link">Apply Now</a>
             </nav>
           </div>
@@ -111,7 +111,7 @@
           <a href="#" class="footer-brand w-inline-block"><img src="images/Untitled-design---2025-09-25T101744.509.png" loading="lazy" width="421" sizes="(max-width: 479px) 100vw, 421px" alt="" srcset="images/Untitled-design---2025-09-25T101744.509-p-500.png 500w, images/Untitled-design---2025-09-25T101744.509-p-800.png 800w, images/Untitled-design---2025-09-25T101744.509-p-1080.png 1080w, images/Untitled-design---2025-09-25T101744.509.png 1350w"></a>
         </div>
         <div class="row-x-small-4">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="social-link w-inline-block">
+          <a href="https://supersmall.substack.com/" target="_blank" class="social-link w-inline-block">
             <div class="social-inner">
               <div class="icon-regular-10 w-embed"><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M22.539 8.242H1.46V5.406H22.539V8.242ZM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46ZM22.539 0H1.46V2.836H22.539V0Z" fill="currentColor"></path>
@@ -120,7 +120,7 @@
           </a>
         </div>
         <div style="text-align: center;">
-          <a href="https://supersmallai.substack.com/" target="_blank" class="footer-substack-button">
+          <a href="https://supersmall.substack.com/" target="_blank" class="footer-substack-button">
             SUBSCRIBE TO SUBSTACK
           </a>
         </div>


### PR DESCRIPTION
…tack.com

- Updated Substack links across all 12 website pages
- Navigation menus now point to the new supersmall.substack.com URL
- Footer links updated to match new Substack domain
- Maintains consistency across entire site

🤖 Generated with [Claude Code](https://claude.ai/code)